### PR TITLE
Unchained Action Economy Fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+## 0.12.0
+- Add Chinese Translation (Huge Thanks to [@NaricaNardica](https://github.com/NaricaNardica))
+- Add French Translation (Huge Thanks to [@guillaume-gc](https://github.com/guillaume-gc))
+- Fix unchained action economy crashing combat hud
+- Fix equipment tooltips showing broken data
+- No longer exclude actions with an activation cost larger than 1 action (mostly relevant for UC action economy)
+- Fix unchained action economy cost not being properly deducted
+
 ## 0.11.2
 - Fix item tooltips breaking when no material data is available
 - Fix additional deprecation warnings

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module currently supports the following languages:
 - English
 - German (Deutsch)
 - French (Huge Thanks to [@guillaume-gc](https://github.com/guillaume-gc))
-- Chinese (Hue Thanks to [@NaricaNardica](https://github.com/NaricaNardica))
+- Chinese (Huge Thanks to [@NaricaNardica](https://github.com/NaricaNardica))
 
 Should you wish to contribute further languages, please feel free to open a pull request or contact me directly.
 

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "enhancedcombathud-pf1",
   "title": "Argon - Combat HUD (PF1)",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/modules/argon/buttons/buttonPanelButton.mjs
+++ b/modules/argon/buttons/buttonPanelButton.mjs
@@ -136,28 +136,14 @@ export function buttonPanelItemButton(ARGON) {
         get validItems() {
             const itemsOfType = this.actor.items.filter(item => item.type === this.type);
             return itemsOfType.filter(item => {
-                if (!item.actions) {
+                if (
+                    !item.actions?.size
+                    || (item.isCharged && !item.charges)
+                ) {
                     return false;
                 }
 
-                if (item.isCharged && !item.charges) {
-                    return false;
-                }
-
-                for (let action of item.actions) {
-                    if (this.isUnchained) {
-                        if (action.activation.unchained.type === this.actionType) {
-                            return true;
-                        }
-                    } else {
-                        if (action.activation.type === this.actionType
-                            && action.activation.cost === 1) {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
+                return item.actions.some(action => action.activation.type === this.actionType && action.activation.cost <= this.parent.maxActions);
             });
         }
 
@@ -173,8 +159,10 @@ export function buttonPanelItemButton(ARGON) {
             switch (this.type) {
                 case "consumable":
                     return `modules/${ModuleName}/icons/vial.svg`;
+
                 case "equipment":
                     return `modules/${ModuleName}/icons/gem-chain.svg`;
+
                 case "feat":
                     return "modules/enhancedcombathud/icons/svg/mighty-force.svg";
             }
@@ -293,20 +281,7 @@ export function spellbookButtonPanelActionButton(ARGON) {
                     }
                 }
 
-                for (let action of item.actions) {
-                    if (this.isUnchained) {
-                        if (action.activation.unchained.type === this.actionType) {
-                            return true;
-                        }
-                    } else {
-                        if (action.activation.type === this.actionType
-                            && action.activation.cost === 1) {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
+                return item.actions.some(action => action.activation.type === this.actionType && action.activation.cost <= this.parent.maxActions);
             });
         }
 
@@ -381,7 +356,7 @@ export function spellButtonPanelActionButton(ARGON) {
                 if (item.type !== "spell") continue;
 
                 if (!item.canUse) {
-                   continue;
+                    continue;
                 }
 
                 if (item.spellbook.spellPreparationMode === "prepared" && !item.useSpellPoints()) {
@@ -396,19 +371,10 @@ export function spellButtonPanelActionButton(ARGON) {
 
                 if (!usedSpellbooks.includes(item.system.spellbook)) continue;
 
-                if (!item.actions) continue;
+                if (!item.actions?.size) continue;
 
-                for (let action of item.actions) {
-                    if (this.isUnchained) {
-                        if (action.activation.unchained.type === this.actionType) {
-                            return true;
-                        }
-                    } else {
-                        if (action.activation.type === this.actionType
-                            && action.activation.cost === 1) {
-                            return true;
-                        }
-                    }
+                if(item.actions.some(action => action.activation.type === this.actionType && action.activation.cost <= this.parent.maxActions)) {
+                    return true;
                 }
             }
 

--- a/modules/argon/buttons/itemButton.mjs
+++ b/modules/argon/buttons/itemButton.mjs
@@ -37,7 +37,7 @@ export function itemButton(ARGON) {
         }
 
         get actionCost() {
-            return this.isUnchained ? this.item.defaultAction?.activation.unchained.cost : 1;
+            return this.isUnchained ? this.item.defaultAction?.activation.cost : 1;
         }
 
         get isValid() {
@@ -175,15 +175,15 @@ export function itemButton(ARGON) {
 
                 case "equipment":
                     if (item.system.subType === "wondrous") {
-                        subtitle = item.system.subType ? pf1.config.equipmentSlots[item.system.slot] : null;
+                        subtitle = item.system.subType ? pf1.config.equipmentSlots.wondrous[item.system.slot] : null;
                     } else {
-                        subtitle = item.system.subType ? pf1.config.equipmentTypes[item.system.subType] : null;
+                        subtitle = item.system.subType ? pf1.config.equipmentTypes[item.system.subType]._label : null;
                     }
 
                     if (item.system.armor.value) {
                         details.push({
                             label: game.i18n.localize("PF1.ACNormal"),
-                            value: ('+' + item.system.armor.value).replace('+-', '-')
+                            value: ('+' + (item.system.armor.value + item.system.armor.enh)).replace('+-', '-')
                         })
                         details.push({
                             label: game.i18n.localize("PF1.MaxDexShort"),


### PR DESCRIPTION
- Fix unchained action economy crashing combat hud
- Fix equipment tooltips showing broken data
- No longer exclude actions with an activation cost larger than 1 action (mostly relevant for UC action economy)
- Fix unchained action economy cost not being properly deducted

Closes #28 